### PR TITLE
Fixed: The commit d451b1cd5d2cc6af7be7bf603ae3cce32d652203 was no good.

### DIFF
--- a/src/SIM/SIMoutput.C
+++ b/src/SIM/SIMoutput.C
@@ -532,8 +532,9 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   }
 
   std::array<IntVec,2> vID;
-  std::vector<IntVec> sID;
-  sID.reserve(haveXsol ? nf+nf : nf);
+  std::vector<IntVec> sID, xID;
+  sID.reserve(nf);
+  if (haveXsol) xID.reserve(nf);
 
   Matrix field;
   Vector lovec;
@@ -567,8 +568,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
     if (myProblem) // Compute application-specific primary solution quantities
       myProblem->primaryScalarFields(field);
 
-    size_t k = 0;
-    if (!this->writeScalarFields(field,geomID,k,nBlock,sID))
+    if (!this->writeScalarFields(field,geomID,nBlock,sID))
       return -3;
 
     if (haveXsol)
@@ -610,7 +610,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
       }
 
       if (haveXsol)
-        if (!this->writeScalarFields(field,geomID,k,nBlock,sID))
+        if (!this->writeScalarFields(field,geomID,nBlock,xID))
           return false;
 
       if (!myVtf->writeVres(field,++nBlock,geomID,nVcomp))
@@ -622,7 +622,7 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
 
   // Write result block identifications
 
-  size_t i, j;
+  size_t i;
   bool ok = true;
   std::string pname(pvecName ? pvecName : "Solution");
   for (i = 0; i < 2 && ok; i++)
@@ -641,18 +641,18 @@ int SIMoutput::writeGlvS1 (const Vector& psol, int iStep, int& nBlock,
   std::vector<std::string> xname;
   if (haveXsol) xname.reserve(nf);
   if (nf > 1) pname += "_w";
-  for (i = j = 0; i < nf && j < sID.size() && !sID[j].empty() && ok; i++)
+  for (i = 0; i < sID.size() && !sID[i].empty() && ok; i++)
   {
     if (myProblem && (!pvecName || nf > nVcomp))
       pname = myProblem->getField1Name(i);
     else if (nf > 1)
       (*pname.rbegin()) ++;
-    ok = myVtf->writeSblk(sID[j++],pname.c_str(),idBlock++,iStep);
+    ok = myVtf->writeSblk(sID[i],pname.c_str(),idBlock++,iStep);
     if (haveXsol) xname.push_back("Exact " + pname);
   }
 
-  for (i = 0; i < xname.size() && j < sID.size() && !sID[j].empty() && ok; i++)
-    ok = myVtf->writeSblk(sID[j++],xname[i].c_str(),idBlock++,iStep);
+  for (i = 0; i < xname.size() && i < xID.size() && !xID[i].empty() && ok; i++)
+    ok = myVtf->writeSblk(xID[i],xname[i].c_str(),idBlock++,iStep);
 
   return ok ? idBlock : -4;
 }
@@ -717,7 +717,7 @@ bool SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
 
     size_t k = 0;
     myModel[i]->filterResults(field,myVtf->getBlock(++geomID));
-    if (!this->writeScalarFields(field,geomID,k,nBlock,sID))
+    if (!this->writeScalarFields(field,geomID,nBlock,sID,&k))
       return false;
 
     // Write principal directions, if any, as vector fields
@@ -741,7 +741,7 @@ bool SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
         return false;
 
       myModel[i]->filterResults(field,myVtf->getBlock(geomID));
-      if (!this->writeScalarFields(field,geomID,k,nBlock,sID))
+      if (!this->writeScalarFields(field,geomID,nBlock,sID,&k))
         return false;
     }
 
@@ -772,7 +772,7 @@ bool SIMoutput::writeGlvS2 (const Vector& psol, int iStep, int& nBlock,
       }
 
       if (haveAsol)
-        if (!this->writeScalarFields(field,geomID,k,nBlock,sID))
+        if (!this->writeScalarFields(field,geomID,nBlock,sID,&k))
           return false;
     }
   }
@@ -875,7 +875,7 @@ bool SIMoutput::writeGlvP (const Vector& ssol, int iStep, int& nBlock,
 
     size_t j = 1; // Write out to VTF-file as scalar fields
     const ElementBlock* grid = myVtf->getBlock(++geomID);
-    if (!this->writeScalarFields(field,geomID,j,nBlock,sID))
+    if (!this->writeScalarFields(field,geomID,nBlock,sID,&j))
       return false;
 
     if (maxVal) // Update extremal values
@@ -900,9 +900,12 @@ bool SIMoutput::writeGlvP (const Vector& ssol, int iStep, int& nBlock,
 }
 
 
-bool SIMoutput::writeScalarFields (const Matrix& field, int geomID, size_t& k,
-                                   int& nBlock, std::vector<IntVec>& sID)
+bool SIMoutput::writeScalarFields (const Matrix& field, int geomID,
+                                   int& nBlock, std::vector<IntVec>& sID,
+                                   size_t* i)
 {
+  size_t nS = 0;
+  size_t& k = i ? *i : nS;
   for (size_t j = 1; j <= field.rows(); j++, k++)
     if (!myVtf->writeNres(field.getRow(j),++nBlock,geomID))
       return false;

--- a/src/SIM/SIMoutput.h
+++ b/src/SIM/SIMoutput.h
@@ -304,8 +304,9 @@ protected:
 
 private:
   //! \brief Private helper to write out scalar fields to VTF-file.
-  bool writeScalarFields(const Matrix& field, int geomID, size_t& k,
-                         int& nBlock, std::vector< std::vector<int> >& sID);
+  bool writeScalarFields(const Matrix& field, int geomID,
+                         int& nBlock, std::vector< std::vector<int> >& sID,
+                         size_t* i = nullptr);
 
   //! \brief Struct defining a result sampling point.
   struct ResultPoint


### PR DESCRIPTION
It broke the nonlinear shell VTF output in that the sqrt(u^2+v^2+w^2)
quantity disappeared. Now doing this a different way instead not relying
on the nf-parameter, but using a separate ID-array for the exact fields.

Prøv med denne istedet. Håper og tror det også skal fungere for mixed.