### PR TITLE
fixup! added: ASMu2Dnurbs

### DIFF
--- a/src/ASM/LR/ASMu2D.C
+++ b/src/ASM/LR/ASMu2D.C
@@ -300,7 +300,7 @@ bool ASMu2D::refine (const RealFunc& refC, double refTol)
 {
   Go::Point X0;
   int iel = 0;
-  std::vector<int> elements;
+  IntVec elements;
   for (const LR::Element* elm : lrspline->getAllElements())
   {
     double u0 = 0.5*(elm->umin() + elm->umax());
@@ -876,8 +876,8 @@ double ASMu2D::getParametricLength (int iel, int dir) const
   const LR::Element* el = lrspline->getElement(iel-1);
   switch (dir)
   {
-  case 1: return el->vmax() - el->vmin();
-  case 2: return el->umax() - el->umin();
+  case 1: return el->umax() - el->umin();
+  case 2: return el->vmax() - el->vmin();
   }
 
   std::cerr <<" *** ASMu2D::getParametricLength: Invalid edge direction "
@@ -1528,8 +1528,12 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
   size_t firstp = iit == firstBp.end() ? 0 : iit->second;
 
   FiniteElement fe;
-  Matrix dNdu, Xnod, Jac;
+  fe.p  = lrspline->order(0) - 1;
+  fe.q  = lrspline->order(1) - 1;
+  fe.xi = fe.eta = edgeDir < 0 ? -1.0 : 1.0;
   double param[3] = { 0.0, 0.0, 0.0 };
+
+  Matrix dNdu, Xnod, Jac;
   Vec4   X(param);
   Vec3   normal;
 
@@ -1539,7 +1543,7 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
   int iel = 0;
   for (const LR::Element* el : lrspline->getAllElements())
   {
-    ++iel;
+    fe.iel = MLGE[iel++];
 #ifdef SP_DEBUG
     if (dbgElm < 0 && iel != -dbgElm)
       continue; // Skipping all elements, except for -dbgElm
@@ -1557,38 +1561,37 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
     if (skipMe) continue;
 
     // Get element edge length in the parameter space
-    double dS = this->getParametricLength(iel,t1);
+    double dS = 0.5*this->getParametricLength(iel,t2);
     if (dS < 0.0) return false; // topology error (probably logic error)
 
     // Set up control point coordinates for current element
     if (!this->getElementCoordinates(Xnod,iel)) return false;
 
+    if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
+      fe.h = this->getElementCorners(iel,fe.XC);
+
     // Initialize element quantities
-    fe.iel = MLGE[iel-1];
-    fe.p   = lrspline->order(0) - 1;
-    fe.q   = lrspline->order(1) - 1;
-    fe.xi  = fe.eta = edgeDir < 0 ? -1.0 : 1.0;
     LocalIntegral* A = integrand.getLocalIntegral(MNPC[iel-1].size(),
                                                   fe.iel,true);
-    if (!integrand.initElementBou(MNPC[iel-1],*A)) return false;
+    bool ok = integrand.initElementBou(MNPC[iel-1],*A);
 
     // Get integration gauss points over this element
     this->getGaussPointParameters(gpar[t2-1],t2-1,nGP,iel,xg);
 
-    if (integrand.getIntegrandType() & Integrand::ELEMENT_CORNERS)
-      fe.h = this->getElementCorners(iel,fe.XC);
 
     // --- Integration loop over all Gauss points along the edge ---------------
 
     fe.iGP = firstp; // Global integration point counter
     firstp += nGP;
 
-    for (int i = 0; i < nGP; i++, fe.iGP++)
+    for (int i = 0; i < nGP && ok; i++, fe.iGP++)
     {
       // Local element coordinates and parameter values
       // of current integration point
-      fe.xi = xg[i];
-      fe.eta = xg[i];
+      if (t1 == 2)
+        fe.xi = xg[i];
+      else
+        fe.eta = xg[i];
       fe.u = param[0] = gpar[0][i];
       fe.v = param[1] = gpar[1][i];
 
@@ -1613,20 +1616,21 @@ bool ASMu2D::integrate (Integrand& integrand, int lIndex,
       X.t = time.t;
 
       // Evaluate the integrand and accumulate element contributions
-      fe.detJxW *= 0.5*dS*wg[i];
-      if (!integrand.evalBou(*A,fe,time,X,normal))
-        return false;
+      fe.detJxW *= dS*wg[i];
+      ok = integrand.evalBou(*A,fe,time,X,normal);
     }
 
     // Finalize the element quantities
-    if (!integrand.finalizeElementBou(*A,fe,time))
-      return false;
+    if (ok && !integrand.finalizeElementBou(*A,fe,time))
+      ok = false;
 
     // Assembly of global system integral
-    if (!glInt.assemble(A,fe.iel))
-      return false;
+    if (ok && !glInt.assemble(A->ref(),fe.iel))
+      ok = false;
 
     A->destruct();
+
+    if (!ok) return false;
 
 #ifdef SP_DEBUG
     if (dbgElm < 0 && iel == -dbgElm)

--- a/src/ASM/LR/ASMu2Dnurbs.h
+++ b/src/ASM/LR/ASMu2Dnurbs.h
@@ -32,46 +32,22 @@ public:
   //! \brief Empty destructor.
   virtual ~ASMu2Dnurbs() {}
 
-  // Methods for model generation and refinement
-  // ===========================================
-
   //! \brief Creates an instance by reading the given input stream.
-  virtual bool read(std::istream&);
-
-  //! \brief Refines the parametrization by inserting tensor knots uniformly.
-  //! \param[in] dir Parameter direction to refine
-  //! \param[in] nInsert Number of extra knots to insert in each knot-span
-  virtual bool uniformRefine(int dir, int nInsert);
-  //! \brief Refines the parametrization by inserting extra tensor knots.
-  //! \param[in] dir Parameter direction to refine
-  //! \param[in] xi Relative positions of added knots in each existing knot span
-  //! \param[in] scale Scaling factor for the added knot values
-  virtual bool refine(int dir, const RealArray& xi, double scale);
-  //! \brief Raises the order of the tensor spline object for this patch.
-  //! \param[in] ru Number of times to raise the order in u-direction
-  //! \param[in] rv Number of times to raise the order in v-direction
-  virtual bool raiseOrder(int ru, int rv);
-
-  //! \brief Returns a matrix with nodal coordinates for an element.
-  //! \param[in] iel 1-based element index
-  //! \param[out] X 3\f$\times\f$n-matrix, where \a n is the number of nodes
-  //! in one element
-  virtual bool getElementCoordinates(Matrix& X, int iel) const;
+  virtual bool read(std::istream& is);
 
 protected:
-  //! \brief Evaluates the basis functions and derivatives of order \a derivs
-  //! of an element.
-  virtual bool evaluateBasis(int iel, FiniteElement& el, int derivs = 0) const;
+  //! \brief Evaluates the basis functions and derivatives of an element.
+  virtual bool evaluateBasis(int iel, FiniteElement& fe, int derivs) const;
 
   //! \brief Evaluate basis functions in a point.
   virtual void computeBasis(double u, double v,
                             Go::BasisPtsSf& bas, int iel,
-                            const LR::LRSplineSurface* spline = nullptr) const;
+                            const LR::LRSplineSurface* spline) const;
 
   //! \brief Evaluate basis functions and first derivatives in a point.
   virtual void computeBasis(double u, double v,
                             Go::BasisDerivsSf& bas, int iel,
-                            const LR::LRSplineSurface* spline = nullptr) const;
+                            const LR::LRSplineSurface* spline) const;
   //! \brief Evaluate basis functions and two derivatives in a point.
   virtual void computeBasis(double u, double v,
                             Go::BasisDerivsSf2& bas, int iel) const;
@@ -84,7 +60,7 @@ protected:
   virtual LR::LRSplineSurface* createLRfromTensor();
 
 private:
-  bool noNurbs; //!< If true, we read a spline and thus forward to ASMu2D.
+  bool noNurbs; //!< If \e true, we read a spline and thus forward to ASMu2D
 };
 
 #endif


### PR DESCRIPTION
Modified the `ASMu2D::evalPoint` method a bit, such that it also can take u,v parameters directly as input, and avoid computing via [0,1] domain back and forth.
The old getElementCorners implementation was probably wrong anyway in the event of a non-zero starting parameter.

With this I think you also can squash eff9f827560286f2f618acaf48708d1656734b53 into the same commit, as it is very tied to the introduction of the NURBS sub-class in my opinion.