### PR TITLE
Fix lrnurbs slowness

### DIFF
--- a/src/ASM/ASMs2D.C
+++ b/src/ASM/ASMs2D.C
@@ -2563,6 +2563,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const Vector& locSol,
                            const RealArray* gpar,
                            bool regular, int deriv, int) const
 {
+  PROFILE2("ASMs2D::evalSol(P)");
+
   // Evaluate the basis functions at all points
   size_t nPoints = gpar[0].size();
   std::vector<Go::BasisPtsSf>     spline0(regular || deriv != 0 ? 0 : nPoints);
@@ -2755,6 +2757,8 @@ bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 bool ASMs2D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
                            const RealArray* gpar, bool regular) const
 {
+  PROFILE2("ASMs2D::evalSol(S)");
+
   sField.resize(0,0);
 
   // Evaluate the basis functions and their derivatives at all points

--- a/src/ASM/ASMs3D.C
+++ b/src/ASM/ASMs3D.C
@@ -2793,7 +2793,7 @@ bool ASMs3D::evalSolution (Matrix& sField, const Vector& locSol,
                            const RealArray* gpar,
                            bool regular, int deriv, int) const
 {
-  sField.resize(0,0);
+  PROFILE2("ASMs3D::evalSol(P)");
 
   // Evaluate the basis functions and/or their derivatives at all points
   size_t nPoints = gpar[0].size();
@@ -2954,6 +2954,8 @@ bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 bool ASMs3D::evalSolution (Matrix& sField, const IntegrandBase& integrand,
 			   const RealArray* gpar, bool regular) const
 {
+  PROFILE2("ASMs3D::evalSol(S)");
+
   sField.resize(0,0);
 
   // Evaluate the basis functions and their derivatives at all points

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -68,10 +68,9 @@ bool ASMu2Dnurbs::evaluateBasis (int iel, FiniteElement& fe,
   }
   const Matrix& C = bezierExtract[iel];
 
-  int wi = lrspline->getBasisfunction(MNPC[iel][0])->dim()-1;
-  RealArray w(MNPC[iel].size());
-  for (size_t i = 0; i < w.size(); i++)
-    w[i] = lrspline->getBasisfunction(MNPC[iel][i])->cp(wi);
+  RealArray w; w.reserve(el->nBasisFunctions());
+  for (const LR::Basisfunction* func : el->support())
+    w.push_back(func->cp(func->dim()-1));
 
   if (derivs < 1) {
     Matrix B;
@@ -102,8 +101,8 @@ bool ASMu2Dnurbs::evaluateBasis (int iel, FiniteElement& fe,
     Vector Bv(p); // Bezier basis functions differentiated wrt v
 
     size_t i, j, k = 0;
-    for (j = 0; j < Nv.size(); j+=(derivs+1))
-      for (i = 0; i < Nu.size(); i+=(derivs+1), k++) {
+    for (j = 0; j < Nv.size(); j += derivs+1)
+      for (i = 0; i < Nu.size(); i += derivs+1, k++) {
         B[k]  = Nu[i  ]*Nv[j  ];
         Bu[k] = Nu[i+1]*Nv[j  ];
         Bv[k] = Nu[i  ]*Nv[j+1];
@@ -118,7 +117,7 @@ bool ASMu2Dnurbs::evaluateBasis (int iel, FiniteElement& fe,
     double Wdereta = dNeta.dot(w);
 
     Matrix dNdu(w.size(),2);
-    for (size_t i = 1; i <= fe.N.size(); i++) {
+    for (i = 1; i <= fe.N.size(); i++) {
       fe.N(i)  *= w[i-1]/W;
       dNdu(i,1) = (dNxi(i)*W  - fe.N(i)*Wderxi )*w[i-1]/(W*W);
       dNdu(i,2) = (dNeta(i)*W - fe.N(i)*Wdereta)*w[i-1]/(W*W);
@@ -166,14 +165,13 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   if (!spline)
     spline = lrspline.get();
 
+  const LR::Element* el = spline->getElement(iel);
+
   Go::BasisPtsSf tmp;
   spline->computeBasis(u,v,tmp,iel);
-  int wi = spline->getBasisfunction(MNPC[iel][0])->dim()-1;
-  Vector w(tmp.basisValues.size());
-  const LR::Element* el = lrspline->getElement(iel);
-  size_t i = 0;
+  Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
-    w[i++] = func->cp(wi);
+    w.push_back(func->cp(func->dim()-1));
 
   double W = w.dot(tmp.basisValues);
 
@@ -195,14 +193,13 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   if (!spline)
     spline = lrspline.get();
 
+  const LR::Element* el = spline->getElement(iel);
+
   Go::BasisDerivsSf tmp;
   spline->computeBasis(u,v,tmp,iel);
-  int wi = spline->getBasisfunction(MNPC[iel][0])->dim()-1;
-  Vector w(tmp.basisValues.size());
-  const LR::Element* el = lrspline->getElement(iel);
-  size_t i = 0;
+  Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
-    w[i++] = func->cp(wi);
+    w.push_back(func->cp(func->dim()-1));
 
   double W  = w.dot(tmp.basisValues);
   double Wx = w.dot(tmp.basisDerivs_u);
@@ -226,14 +223,13 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
 
   PROFILE3("ASMu2Dn::compBasis(2)");
 
+  const LR::Element* el = lrspline->getElement(iel);
+
   Go::BasisDerivsSf2 tmp;
   lrspline->computeBasis(u,v,tmp,iel);
-  int wi = lrspline->getBasisfunction(MNPC[iel][0])->dim()-1;
-  Vector w(tmp.basisValues.size());
-  const LR::Element* el = lrspline->getElement(iel);
-  size_t i = 0;
+  Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
-    w[i++] = func->cp(wi);
+    w.push_back(func->cp(func->dim()-1));
 
   double W   = w.dot(tmp.basisValues);
   double Wx  = w.dot(tmp.basisDerivs_u);
@@ -271,14 +267,13 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
 
   PROFILE3("ASMu2Dn::compBasis(3)");
 
+  const LR::Element* el = lrspline->getElement(iel);
+
   Go::BasisDerivsSf3 tmp;
   lrspline->computeBasis(u,v,tmp,iel);
-  int wi = lrspline->getBasisfunction(MNPC[iel][0])->dim()-1;
-  Vector w(tmp.basisValues.size());
-  const LR::Element* el = lrspline->getElement(iel);
-  size_t i = 0;
+  Vector w; w.reserve(tmp.basisValues.size());
   for (const LR::Basisfunction* func : el->support())
-    w[i++] = func->cp(wi);
+    w.push_back(func->cp(func->dim()-1));
 
   double W    = w.dot(tmp.basisValues);
   double Wx   = w.dot(tmp.basisDerivs_u);

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -170,8 +170,10 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   spline->computeBasis(u,v,tmp,iel);
   int wi = spline->getBasisfunction(MNPC[iel][0])->dim()-1;
   Vector w(tmp.basisValues.size());
-  for (size_t i = 0; i < w.size(); i++)
-    w[i] = spline->getBasisfunction(MNPC[iel][i])->cp(wi);
+  const LR::Element* el = lrspline->getElement(iel);
+  size_t i = 0;
+  for (const LR::Basisfunction* func : el->support())
+    w[i++] = func->cp(wi);
 
   double W = w.dot(tmp.basisValues);
 
@@ -197,8 +199,10 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   spline->computeBasis(u,v,tmp,iel);
   int wi = spline->getBasisfunction(MNPC[iel][0])->dim()-1;
   Vector w(tmp.basisValues.size());
-  for (size_t i = 0; i < w.size(); i++)
-    w[i] = spline->getBasisfunction(MNPC[iel][i])->cp(wi);
+  const LR::Element* el = lrspline->getElement(iel);
+  size_t i = 0;
+  for (const LR::Basisfunction* func : el->support())
+    w[i++] = func->cp(wi);
 
   double W  = w.dot(tmp.basisValues);
   double Wx = w.dot(tmp.basisDerivs_u);
@@ -226,8 +230,10 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   lrspline->computeBasis(u,v,tmp,iel);
   int wi = lrspline->getBasisfunction(MNPC[iel][0])->dim()-1;
   Vector w(tmp.basisValues.size());
-  for (size_t i = 0; i < w.size(); i++)
-    w[i] = lrspline->getBasisfunction(MNPC[iel][i])->cp(wi);
+  const LR::Element* el = lrspline->getElement(iel);
+  size_t i = 0;
+  for (const LR::Basisfunction* func : el->support())
+    w[i++] = func->cp(wi);
 
   double W   = w.dot(tmp.basisValues);
   double Wx  = w.dot(tmp.basisDerivs_u);
@@ -269,8 +275,10 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   lrspline->computeBasis(u,v,tmp,iel);
   int wi = lrspline->getBasisfunction(MNPC[iel][0])->dim()-1;
   Vector w(tmp.basisValues.size());
-  for (size_t i = 0; i < w.size(); i++)
-    w[i] = lrspline->getBasisfunction(MNPC[iel][i])->cp(wi);
+  const LR::Element* el = lrspline->getElement(iel);
+  size_t i = 0;
+  for (const LR::Basisfunction* func : el->support())
+    w[i++] = func->cp(wi);
 
   double W    = w.dot(tmp.basisValues);
   double Wx   = w.dot(tmp.basisDerivs_u);

--- a/src/ASM/LR/ASMu2Dnurbs.C
+++ b/src/ASM/LR/ASMu2Dnurbs.C
@@ -20,6 +20,7 @@
 #include "ASMu2Dnurbs.h"
 #include "FiniteElement.h"
 #include "CoordinateMapping.h"
+#include "Profiler.h"
 
 
 ASMu2Dnurbs::ASMu2Dnurbs (unsigned char n_s, unsigned char n_f)
@@ -54,6 +55,8 @@ bool ASMu2Dnurbs::evaluateBasis (int iel, FiniteElement& fe,
 
   const LR::Element* el = lrspline->getElement(iel);
   if (!el) return false;
+
+  PROFILE3("ASMu2Dn::evalBasis");
 
   fe.xi  = 2.0*(fe.u - el->umin()) / (el->umax() - el->umin()) - 1.0;
   fe.eta = 2.0*(fe.v - el->vmin()) / (el->vmax() - el->vmin()) - 1.0;
@@ -158,6 +161,8 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
   if (noNurbs)
     return this->ASMu2D::computeBasis(u,v,bas,iel,spline);
 
+  PROFILE3("ASMu2Dn::compBasis(0)");
+
   if (!spline)
     spline = lrspline.get();
 
@@ -182,6 +187,8 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
 {
   if (noNurbs)
     return this->ASMu2D::computeBasis(u,v,bas,iel,spline);
+
+  PROFILE3("ASMu2Dn::compBasis(1)");
 
   if (!spline)
     spline = lrspline.get();
@@ -212,6 +219,8 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
 {
   if (noNurbs)
     return this->ASMu2D::computeBasis(u,v,bas,iel);
+
+  PROFILE3("ASMu2Dn::compBasis(2)");
 
   Go::BasisDerivsSf2 tmp;
   lrspline->computeBasis(u,v,tmp,iel);
@@ -253,6 +262,8 @@ void ASMu2Dnurbs::computeBasis (double u, double v,
 {
   if (noNurbs)
     return this->ASMu2D::computeBasis(u,v,bas,iel);
+
+  PROFILE3("ASMu2Dn::compBasis(3)");
 
   Go::BasisDerivsSf3 tmp;
   lrspline->computeBasis(u,v,tmp,iel);


### PR DESCRIPTION
Det ser ut som at dette gjør susen ja. Har nå kjørt adaptivt NURBS med p=2 og p=3, og begge gir identiske resultater som før, men med drastisk kjappere kode (17633s --> 387s for p=3).

Men her er en fixup jeg tror bør inn (du hadde glemt evalBasis, bl.a.), samt de ekstra profileringene i en separat commit. Legg gjerne den siste først (altså e0ad787), slik at det er mulig (i prinsippet) å måle gammel-metoden  også ved å sjekke ut den committen.